### PR TITLE
Choose a specimen image if there is one available

### DIFF
--- a/ckanext/list/theme/public/scripts/list-view.js
+++ b/ckanext/list/theme/public/scripts/list-view.js
@@ -126,7 +126,21 @@ this.list = this.list || {};
                     if (resourceView.image_field) {
                         var img = data.attributes[resourceView.image_field];
                         if ($.type(img) !== "undefined" && img) {
-                            record.image = JSON.parse(img)[0];
+                            var images = JSON.parse(img);
+                            // by default we'll use the first image for the record
+                            var imageIndex = 0;
+                            // if there are multiple images available, see if
+                            // there's a "specimen" image and use it if so
+                            if (images.length > 0) {
+                                for (var i = 0, l = images.length; i < l; i++) {
+                                    if (images[i].category === 'Specimen') {
+                                        imageIndex = i;
+                                        break;
+                                    }
+                                }
+                            }
+                            // set the record's image
+                            record.image = images[imageIndex];
                             // Yuck!! Hack for NHM MAM images.
                             // FIXME: Mustache template per dataset resource
                             if(record.image.identifier.indexOf('www.nhm.ac.uk/services')!== -1){


### PR DESCRIPTION
Currently we just show the first image in the list of available images for a specimen, this change attempts to use the first image labelled as a "specimen" and if there isn't one falls back to the old behaviour.

Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/84