### PR TITLE
Support associatedOccurrences link

### DIFF
--- a/ckanext/list/theme/assets/scripts/list-view.js
+++ b/ckanext/list/theme/assets/scripts/list-view.js
@@ -201,10 +201,16 @@ this.list = this.list || {};
           }
           $.each(resourceView.fields, function (_, fieldName) {
             if (data.attributes[fieldName]) {
-              record.attributes.push({
+              let attribute = {
                 label: self.fieldNameToLabel(fieldName),
                 value: data.attributes[fieldName],
-              });
+              };
+              if (fieldName === 'associatedOccurrences') {
+                const guid = attribute.value.slice(9);
+                const url = `${document.location.origin}/object/${guid}`;
+                attribute.value = `<a href="${url}" target='_blank'>${data.attributes[fieldName]}</a>`;
+              }
+              record.attributes.push(attribute);
             }
           });
           return record;

--- a/ckanext/list/theme/public/mustache_templates/list.mustache
+++ b/ckanext/list/theme/public/mustache_templates/list.mustache
@@ -7,7 +7,7 @@
                 </h4>
                 <ul class="list-unstyled">
                 {{#attributes}}
-                    <li><strong>{{label}}</strong>: {{value}}</li>
+                    <li><strong>{{label}}</strong>: {{{value}}}</li>
                 {{/attributes}}
                 </ul>
             </div>


### PR DESCRIPTION
This is really an NHM specific change but because of the way the list view is implemented it would be a huge amount of work to implement the hooks and such necessary to modify something at this low level in the processing flow. Given we're going to be moving away from ckanext-list and friends soon and there aren't many users of this, plus this change shouldn't really impact anyone else even if they are using this extension, we'll just implement it here and we can always revert it when we stop using it.

_This can be held back until the preperations are available on the Data Portal._

- [x] I have read the [section on commits and pull requests](https://github.com/NaturalHistoryMuseum/ckanext-list/blob/main/CONTRIBUTING.md#commits-and-pull-requests) in `CONTRIBUTING.md`

